### PR TITLE
Update helpers to fix right Image positioning

### DIFF
--- a/ReadmeGenerator/helpers.py
+++ b/ReadmeGenerator/helpers.py
@@ -67,8 +67,9 @@ def tech_stack(data, context):
     Generate the tech stack section of the README.
     """
     title = process_title(data["title"], context)
+    image = right_image(data["right_image"], "")
     tech = "- " + "\n- ".join(data["tech"])
-    return f"{title}\n{tech}\n"
+    return f"{title}\n{image}\n{tech}\n"
 
 
 def awesome_projects(data, context):


### PR DESCRIPTION
At some point the right image's position went higher than the Skills' category title. This change inserts it right between the title and the skills content so that it is positioned correclty.